### PR TITLE
Update support URL and improve button injection in chat UI

### DIFF
--- a/userscripts/TwitchViewBotCommands.user.js
+++ b/userscripts/TwitchViewBotCommands.user.js
@@ -7,7 +7,7 @@
 // @description See all the available bot commands from popular bots that broadcasters use, from the comfort of your Twitch chat!
 // @icon        https://i.imgur.com/q4rNQOb.png
 // @license     MIT
-// @home        https://github.com/1011025m/userfiles
+// @supportURL  https://github.com/1011025m/userfiles
 // @updateURL   https://github.com/1011025m/userfiles/raw/main/userscripts/TwitchViewBotCommands.user.js
 // @downloadURL https://github.com/1011025m/userfiles/raw/main/userscripts/TwitchViewBotCommands.user.js
 // @unwrap
@@ -685,10 +685,10 @@
     }
 
     function injectViewCommandsButton() {
-        const chatButtonsRightContainer = document.querySelector('.chat-input__buttons-container > div > div:has(button[data-a-target="chat-send-button"])')
+        const parentContainer = document.querySelector('[data-test-selector="chat-input-buttons-container"]');
+        const targetDiv = parentContainer.children[1];
         const viewCommandsButton = document.createElement('div')
         viewCommandsButton.classList.add('viewchatcommands-button')
-        chatButtonsRightContainer.insertAdjacentElement('beforebegin', viewCommandsButton)
         const childDiv = document.createElement('div')
         viewCommandsButton.append(childDiv)
         const childButton = document.createElement('button')
@@ -696,12 +696,13 @@
         const iconDiv = document.createElement('div')
         iconDiv.classList.add('open')
         childButton.append(iconDiv)
+        targetDiv.appendChild(viewCommandsButton);
+        viewCommandsButton.appendChild(childButton);
 
         childButton.onclick = async () => {
             await renderCommandList()
         }
     }
-
 
     // Run
     let currChannelName = null


### PR DESCRIPTION
Replace the @home metadata with @supportURL and revise how the view-commands button is injected into the chat UI.

The complex :has() selector was removed in favor of selecting [data-test-selector="chat-input-buttons-container"] and using direct child indexing, and insertion was changed from insertAdjacentElement to appendChild/append to reliably attach the new button and its child elements.

These changes make the DOM targeting and insertion more robust against selector support and structure changes.

## Before
<img width="336" height="130" alt="image" src="https://github.com/user-attachments/assets/27f4fbf8-4ac0-4ebc-bfd7-5b458c65009e" />

## After
<img width="338" height="101" alt="image" src="https://github.com/user-attachments/assets/0713e422-ac8b-424a-9a3a-c4820afafad3" />
